### PR TITLE
Fix referral reward flag for categories

### DIFF
--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -114,19 +114,17 @@ class Categories(Database.BASE):
     allow_referral_rewards = Column(Boolean, nullable=False, default=True)
     item = relationship("Goods", back_populates="category")
 
-    def __init__(self, name: str, parent_name: str | None = None,
-                 allow_discounts: bool = True, allow_referral_rewards: bool = True):
+    def __init__(
+        self,
+        name: str,
+        parent_name: str | None = None,
+        allow_discounts: bool = True,
+        allow_referral_rewards: bool = True,
+    ):
         self.name = name
         self.parent_name = parent_name
         self.allow_discounts = allow_discounts
         self.allow_referral_rewards = allow_referral_rewards
-
-    item = relationship("Goods", back_populates="category")
-
-    def __init__(self, name: str, parent_name: str | None = None, allow_discounts: bool = True):
-        self.name = name
-        self.parent_name = parent_name
-        self.allow_discounts = allow_discounts
 
 
 class Goods(Database.BASE):

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -777,7 +777,7 @@ async def main_category_referral_decision(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     if TgConfig.STATE.get(user_id) != 'add_main_category_referral':
         return
-    allow_ref = call.data.endswith('_yes')
+    block_referrals = call.data.endswith('_yes')
     name = TgConfig.STATE.pop(f'{user_id}_new_main_category', None)
     allow_discounts = TgConfig.STATE.pop(f'{user_id}_new_main_category_discount', True)
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
@@ -787,7 +787,7 @@ async def main_category_referral_decision(call: CallbackQuery):
     create_category(
         name,
         allow_discounts=allow_discounts,
-        allow_referral_rewards=allow_ref,
+        allow_referral_rewards=not block_referrals,
     )
     await bot.edit_message_text(
         chat_id=call.message.chat.id,


### PR DESCRIPTION
## Summary
- ensure category model accepts referral reward flag
- block referral rewards in main categories when requested

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be0a0fc90c8332a1675be94a5d747c